### PR TITLE
Fix a bug in get_codebook_entry method

### DIFF
--- a/latent_motion_tokenizer/src/models/vector_quantizer.py
+++ b/latent_motion_tokenizer/src/models/vector_quantizer.py
@@ -123,7 +123,7 @@ class VectorQuantizer2(nn.Module):
 
     def get_codebook_entry(self, indices):
         if self.remap is not None and self.unknown_index != "closest":
-            indices = indices.reshape(shape[0], -1)  # add batch axis
+            indices = indices.reshape(indices.shape[0], -1)  # add batch axis
             indices = self.unmap_to_all(indices)
             indices = indices.reshape(-1)  # flatten again
 


### PR DESCRIPTION
First of all, I would like to express my sincere thanks for sharing this amazing project.
While running the code, I encountered a small issue in one of the lines in your implementation. Specifically, in the line:

```python
indices.reshape(shape[0], -1)
```
I believe there might be an inconsistency, as `shape[0]` isn’t defined in the context, which causes an error. I found that using `indices.shape[0]` instead would resolve the issue, as it correctly refers to the first dimension of the `indices` array. 

I made this change in my local version by modifying the line to:

```python
indices = indices.reshape(indices.shape[0], -1)  # add batch axis
```
After applying it, the code runs as expected now. 
Thank you again for your fantastic work!